### PR TITLE
Refactor message entity to include text length validation. resolves #7

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -1,15 +1,23 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace RazorPagesTestSample.Data
 {
     #region snippet1
+    /// <summary>
+    /// Represents a message entity with a maximum length of 250 characters.
+    /// </summary>
     public class Message
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the message.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// The text is required and has a maximum length of 250 characters.
+        /// </summary>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request introduces a few changes to the `Message` class in the `src/Application/src/RazorPagesTestSample/Data/Message.cs` file, primarily focusing on improving code documentation and updating validation constraints.

Changes to `Message` class:

* Added XML documentation comments to the `Message` class and its properties to improve code readability and maintainability. (`src/Application/src/RazorPagesTestSample/Data/Message.cs`)
* Increased the maximum length for the `Text` property from 200 to 250 characters and updated the corresponding validation error message. (`src/Application/src/RazorPagesTestSample/Data/Message.cs`)